### PR TITLE
fix: money mask

### DIFF
--- a/src/jquery.maskx.js
+++ b/src/jquery.maskx.js
@@ -97,6 +97,8 @@
 		if (!input && /^\d+$/.test(v)) {
 			v = parseInt(v, 10) * 100;
     	}		
+
+    	v = parseFloat(v).toFixed(2)
 		v = String(v || '');
 		v = v.replace(/(\d)\.(\d{1}$)/, "$1.$20");
 		v = v.replace(/\D/g, "");

--- a/src/jquery.maskx.js
+++ b/src/jquery.maskx.js
@@ -94,11 +94,13 @@
 		return v;
 	};
 	plugin.money = function (v, input) {
-		if (!input && /^\d+$/.test(v)) {
-			v = parseInt(v, 10) * 100;
-    	}		
+		if (!/number|string/.test(typeof v)) return ''
 
-		v = parseFloat(v).toFixed(2)
+		if (!input) {
+			v = parseFloat(v).toFixed(2)
+		}
+
+		
 		v = String(v || '');
 		v = v.replace(/(\d)\.(\d{1}$)/, "$1.$20");
 		v = v.replace(/\D/g, "");
@@ -106,6 +108,7 @@
 		v = v.replace(/(\d)(\d{5})$/, "$1.$2");
 		v = v.replace(/(\d)(\d{2})$/, "$1,$2");
 		return v;
+
 	};
 	plugin.phone = function (v) {
 		v = String(v || '');

--- a/src/jquery.maskx.js
+++ b/src/jquery.maskx.js
@@ -98,7 +98,7 @@
 			v = parseInt(v, 10) * 100;
     	}		
 
-    	v = parseFloat(v).toFixed(2)
+		v = parseFloat(v).toFixed(2)
 		v = String(v || '');
 		v = v.replace(/(\d)\.(\d{1}$)/, "$1.$20");
 		v = v.replace(/\D/g, "");

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,7 @@
 			expect(maskx.money(1234)).toEqual('1.234,00');
 			expect(maskx.money(1234.1)).toEqual('1.234,10');
 			expect(maskx.money(1234.98)).toEqual('1.234,98');
+			expect(maskx.money(96.00358749)).toEqual('96,00');
 			expect(maskx.money('1234')).toEqual('1.234,00');
 			expect(maskx.money('12345')).toEqual('12.345,00');
 			expect(maskx.money('1234')).toEqual('1.234,00');

--- a/test/test.js
+++ b/test/test.js
@@ -59,16 +59,36 @@
 			expect(maskx.money('123456789', 'input')).toEqual('1.234.567,89');
 			expect(maskx.money(1234789123, 'input')).toEqual('12.347.891,23');
 		});
+
 		it("should be equal direct template", function() {
 			expect(maskx.money(1234)).toEqual('1.234,00');
 			expect(maskx.money(1234.1)).toEqual('1.234,10');
 			expect(maskx.money(1234.98)).toEqual('1.234,98');
+			expect(maskx.money(101010)).toEqual('101.010,00');
+			expect(maskx.money(100)).toEqual('100,00');
+			expect(maskx.money(100.1)).toEqual('100,10');
+			expect(maskx.money(100.19)).toEqual('100,19');
+			expect(maskx.money(200.191)).toEqual('200,19');
+			expect(maskx.money(200.1919)).toEqual('200,19');
 			expect(maskx.money(96.00358749)).toEqual('96,00');
+			expect(maskx.money(1.1)).toEqual('1,10');
+			expect(maskx.money(1.127)).toEqual('1,13');
+			expect(maskx.money('1.127')).toEqual('1,13');
+			expect(maskx.money('200.1919')).toEqual('200,19');
+			expect(maskx.money('200.999')).toEqual('201,00');
 			expect(maskx.money('1234')).toEqual('1.234,00');
 			expect(maskx.money('12345')).toEqual('12.345,00');
 			expect(maskx.money('1234')).toEqual('1.234,00');
 			expect(maskx.money('1234.1')).toEqual('1.234,10');
 			expect(maskx.money('1234789123')).toEqual('1234.789.123,00');
+			expect(maskx.money(1)).toEqual('1,00');
+			expect(maskx.money(0)).toEqual('0,00');
+			expect(maskx.money({})).toEqual('');
+			expect(maskx.money([{}])).toEqual('');
+			expect(maskx.money()).toEqual('');
+			expect(maskx.money(undefined)).toEqual('');
+			expect(maskx.money(null)).toEqual('');
+			expect(maskx.money(NaN)).toEqual('');
 		});
 	});
 


### PR DESCRIPTION
Máscara de money tava faltando toFixed(2)

![image](https://user-images.githubusercontent.com/440220/46810929-1648a880-cd48-11e8-960a-959dfb4dd8cc.png)

`expect(maskx.money(96.00358749)).toEqual('96,00');`


![image](https://user-images.githubusercontent.com/440220/46812126-6d4f7d00-cd4a-11e8-9b66-8ebcf7eb2a8c.png)
